### PR TITLE
Allow env overrides, query over 50 streams

### DIFF
--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 import time
 import itertools
 import logging
@@ -25,7 +26,7 @@ from .metrics import metrics, metrics_task
 
 # cloudwatch doesn't allow batch spans larger than 24h
 MAX_BATCH_TIME_SPAN = timedelta(hours=24)
-MAX_BATCH_ITEMS = 100
+MAX_BATCH_ITEMS = os.getenv('AWSLOGS_SD_MAX_BATCH_ITEMS', 100)
 BATCH_TIMEOUT_S = 1.0
 MAX_QUEUE_SIZE = 100000
 

--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -411,8 +411,13 @@ def create_log_streams(conf):
     for unit_conf in conf.units:
         group = unit_conf.log_group_name
         name = unit_conf.log_stream_name
+        all_streams = []
         resp = client.describe_log_streams(logGroupName=group)
-        matches = [g for g in resp['logStreams'] if g['logStreamName'] == name]
+        all_streams += resp['logStreams']
+        while 'nextToken' in resp:
+          resp = client.describe_log_streams(logGroupName=group, nextToken=resp['nextToken'])
+          all_streams += resp['logStreams']
+        matches = [g for g in all_streams if g['logStreamName'] == name]
         if not matches:
             logger.info('Creating log stream: %s', name)
             client.create_log_stream(logGroupName=group, logStreamName=name)

--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -26,7 +26,7 @@ from .metrics import metrics, metrics_task
 
 # cloudwatch doesn't allow batch spans larger than 24h
 MAX_BATCH_TIME_SPAN = timedelta(hours=24)
-MAX_BATCH_ITEMS = os.getenv('AWSLOGS_SD_MAX_BATCH_ITEMS', 100)
+MAX_BATCH_ITEMS = int(os.getenv('AWSLOGS_SD_MAX_BATCH_ITEMS', 100))
 BATCH_TIMEOUT_S = 1.0
 MAX_QUEUE_SIZE = 100000
 

--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -301,7 +301,7 @@ def push_records(client, records, unit_conf, state):
         'logEvents': [
             {
                 'timestamp': int(r.date.timestamp() * 1000),
-                'message': r.message
+                'message': r.message[0:1024]
             }
             for r in records
         ],

--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -73,7 +73,8 @@ RFC_SYSLOG_FACILITIES = {
     'local7': 23,
 }
 
-
+loglevel = os.getenv('AWSLOGS_SD_LOGLEVEL', logging.WARNING)
+logging.basicConfig(level=loglevel)
 logger = logging.getLogger('awslogs')
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'awscli-cwlogs',
         'boto3',
         'gevent',
-        'pyyaml',
+        'PyYAML==5.3.1',
         'requests',
         'retrying',
         'systemd-python',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'requests',
         'retrying',
         'systemd-python',
+        'python-dateutil<2.8.1'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Adds a few improvements:

 * Allows `MAX_BATCH_ITEMS` to be adjusted through the environment variable `AWSLOGS_SD_MAX_BATCH_ITEMS`, we found that even at `50` we were getting the error `Upload too large: 1070727 bytes exceeds limit of 1048576`
 * Allows the python log level to be set through the environment variable `AWSLOGS_SD_LOGLEVEL`
 * Handles checking more than 50 log streams (by checking for `nextToken`) before attempting to create a new stream

Thanks for the great project, this is the only one we've found that will forward logs based on `systemd` units! 🙏 